### PR TITLE
Check ffmpeg return code and raise error if other than 0

### DIFF
--- a/regainer.py
+++ b/regainer.py
@@ -622,6 +622,9 @@ class GainScanner:
                 stderr=subprocess.PIPE)
         (_, stderr_data) = await ffmpeg.communicate()
 
+        if ffmpeg.returncode != 0:
+            raise RuntimeError(stderr_data.decode())
+
         result = GainInfo()
         for line_bytes in stderr_data.splitlines():
             line_str = line_bytes.decode()


### PR DESCRIPTION
Check ffmpeg return code to prevent incorrect gain values being updated to files.
Raises `RuntimeError` if return code is not 0.

Fixes https://github.com/kepstin/regainer/issues/7.